### PR TITLE
Bug 1175463 - Add error handling to Overlay::validateAndSet()

### DIFF
--- a/liboverlay/overlay.cpp
+++ b/liboverlay/overlay.cpp
@@ -435,7 +435,16 @@ bool Overlay::validateAndSet(const int& dpy, const int& fbFd) {
     }
 
     //Protect against misbehaving clients
-    return num ? GenericPipe::validateAndSet(pipeArray, num, fbFd) : true;
+    bool ret = num ? GenericPipe::validateAndSet(pipeArray, num, fbFd) : true;
+    if (!ret) {
+        for(int i = 0; i < PipeBook::NUM_PIPES; i++) {
+            if (mPipeBook[i].mDisplay == dpy) {
+                PipeBook::resetAllocation(i);
+                PipeBook::resetUse(i);
+            }
+        }
+    }
+    return ret;
 }
 
 void Overlay::initScalar() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1175463
