### PR TITLE
Bug 1085593 - Do not optimize layers when layer has multiple visible regions

### DIFF
--- a/libhwcomposer/hwc_utils.cpp
+++ b/libhwcomposer/hwc_utils.cpp
@@ -1158,7 +1158,8 @@ void optimizeLayerRects(hwc_context_t *ctx,
         //see if there is no blending required.
         //If it is opaque see if we can substract this region from below layers.
         if(list->hwLayers[i].blending == HWC_BLENDING_NONE &&
-                list->hwLayers[i].planeAlpha == 0xFF) {
+                list->hwLayers[i].planeAlpha == 0xFF &&
+                list->hwLayers[i].visibleRegionScreen.numRects == 1) {
             int j= i-1;
             hwc_rect_t& topframe =
                 (hwc_rect_t&)list->hwLayers[i].displayFrame;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1085593
